### PR TITLE
Use staticcall for dependencies

### DIFF
--- a/contracts/Marmo.sol
+++ b/contracts/Marmo.sol
@@ -7,7 +7,7 @@ import "./commons/Ownable.sol";
 contract Marmo is Ownable {
     event Relayed(
         bytes32 indexed _id,
-        bytes32[] _dependencies,
+        bytes _dependencies,
         address _to,
         uint256 _value,
         bytes _data,
@@ -54,7 +54,7 @@ contract Marmo is Ownable {
     }
 
     function encodeTransactionData(
-        bytes32[] memory _dependencies,
+        bytes memory _dependency,
         address _to,
         uint256 _value,
         bytes memory _data,
@@ -66,7 +66,7 @@ contract Marmo is Ownable {
         return keccak256(
             abi.encodePacked(
                 this,
-                keccak256(abi.encodePacked(_dependencies)),
+                keccak256(_dependency),
                 _to,
                 _value,
                 keccak256(_data),
@@ -79,7 +79,7 @@ contract Marmo is Ownable {
     }
 
     function relay(
-        bytes32[] memory _dependencies,
+        bytes memory _dependency,
         address _to,
         uint256 _value,
         bytes memory _data,
@@ -93,7 +93,7 @@ contract Marmo is Ownable {
         bytes memory data 
     ) {
         bytes32 id = encodeTransactionData(
-            _dependencies,
+            _dependency,
             _to,
             _value,
             _data,
@@ -112,9 +112,11 @@ contract Marmo is Ownable {
 
         require(now < _expiration, "Intent is expired");
         require(tx.gasprice <= _maxGasPrice, "Gas price too high");
-        require(_dependenciesSatisfied(_dependencies), "Dependencies are not satisfied");
+        require(_checkDependency(_dependency), "Dependencies are not satisfied");
+
         address _owner = owner;
         require(msg.sender == _owner || _owner == SigUtils.ecrecover2(id, _signature), "Invalid signature");
+
         require(gasleft() > _minGasLimit, "gasleft too low");
 
         intentReceipt[id] = _encodeReceipt(false, block.number, msg.sender);
@@ -124,7 +126,7 @@ contract Marmo is Ownable {
         
         emit Relayed(
             id,
-            _dependencies,
+            _dependency,
             _to,
             _value,
             _data,
@@ -156,12 +158,25 @@ contract Marmo is Ownable {
         }
     }
 
-    function _dependenciesSatisfied(bytes32[] memory _dependencies) internal view returns (bool) {
-        for (uint256 i; i < _dependencies.length; i++) {
-            (,, address relayer) = _decodeReceipt(intentReceipt[_dependencies[i]]);
-            if (relayer == address(0)) return false;
+    // [160 bits (target) + n bits (data)]
+    function _checkDependency(bytes memory _dependencies) internal view returns (bool result) {
+        if (_dependencies.length == 0) {
+            result = true;
+        } else {
+            assembly {
+                let target := and(mload(add(_dependencies, 20)), 0xffffffffffffffffffffffffffffffffffffffff)
+                let response := mload(0x40)
+                let success := staticcall(
+                    gas,
+                    target,
+                    add(52, _dependencies),
+                    sub(mload(_dependencies), 20),
+                    response,
+                    32
+                )
+
+                result := and(gt(success, 0), gt(mload(response), 0))
+            }
         }
-        
-        return true;
     }
 }

--- a/contracts/Marmo.sol
+++ b/contracts/Marmo.sol
@@ -164,11 +164,10 @@ contract Marmo is Ownable {
             result = true;
         } else {
             assembly {
-                let target := and(mload(add(_dependencies, 20)), 0xffffffffffffffffffffffffffffffffffffffff)
                 let response := mload(0x40)
                 let success := staticcall(
                     gas,
-                    target,
+                    mload(add(_dependencies, 20)),
                     add(52, _dependencies),
                     sub(mload(_dependencies), 20),
                     response,

--- a/contracts/Marmo.sol
+++ b/contracts/Marmo.sol
@@ -112,7 +112,7 @@ contract Marmo is Ownable {
 
         require(now < _expiration, "Intent is expired");
         require(tx.gasprice <= _maxGasPrice, "Gas price too high");
-        require(_checkDependency(_dependency), "Dependencies are not satisfied");
+        require(_checkDependency(_dependency), "Dependency is not satisfied");
 
         address _owner = owner;
         require(msg.sender == _owner || _owner == SigUtils.ecrecover2(id, _signature), "Invalid signature");
@@ -159,17 +159,17 @@ contract Marmo is Ownable {
     }
 
     // [160 bits (target) + n bits (data)]
-    function _checkDependency(bytes memory _dependencies) internal view returns (bool result) {
-        if (_dependencies.length == 0) {
+    function _checkDependency(bytes memory _dependency) internal view returns (bool result) {
+        if (_dependency.length == 0) {
             result = true;
         } else {
             assembly {
                 let response := mload(0x40)
                 let success := staticcall(
                     gas,
-                    mload(add(_dependencies, 20)),
-                    add(52, _dependencies),
-                    sub(mload(_dependencies), 20),
+                    mload(add(_dependency, 20)),
+                    add(52, _dependency),
+                    sub(mload(_dependency), 20),
                     response,
                     32
                 )

--- a/contracts/utils/DepsUtils.sol
+++ b/contracts/utils/DepsUtils.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.5.0;
+
+import "../Marmo.sol";
+
+contract DepsUtils {
+    function multipleDeps(Marmo[] calldata _wallets, bytes32[] calldata _ids) external view returns (bool) {
+        uint256 size = _wallets.length;
+
+        require(
+            size == _ids.length,
+            "_wallets and _ids should have equal length"
+        );
+
+        for (uint256 i = 0; i < size; i++) {
+            if (_wallets[i].relayedBy(_ids[i]) == address(0)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/test/TestMarmoWallets.js
+++ b/test/TestMarmoWallets.js
@@ -79,7 +79,7 @@ contract('Marmo wallets', function (accounts) {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             await web3.eth.sendTransaction({ from: accounts[0], to: wallet.address, value: 1 });
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = accounts[9];
             const value = 1;
             const data = '0x';
@@ -124,7 +124,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -175,7 +175,7 @@ contract('Marmo wallets', function (accounts) {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             await web3.eth.sendTransaction({ from: accounts[0], to: wallet.address, value: 1 });
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = accounts[9];
             const value = 1;
             const data = '0x';
@@ -229,7 +229,7 @@ contract('Marmo wallets', function (accounts) {
         });
         it('Should relay is dependencies are filled', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
-            const ddependencies = "0x";
+            const ddependencies = '0x';
             const dto = accounts[9];
             const dvalue = 0;
             const ddata = '0x';
@@ -278,7 +278,7 @@ contract('Marmo wallets', function (accounts) {
                                 name: 'id',
                             }],
                         }, [idDependency])
-                    )
+                    ),
                 ])
             );
 
@@ -323,7 +323,7 @@ contract('Marmo wallets', function (accounts) {
         });
         it('Should fail to relay if dependencies are not filled', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
-            const ddependencies = "0x";
+            const ddependencies = '0x';
             const dto = accounts[9];
             const dvalue = 1;
             const ddata = '0x';
@@ -355,7 +355,7 @@ contract('Marmo wallets', function (accounts) {
                                 name: 'id',
                             }],
                         }, [idDependency])
-                    )
+                    ),
                 ])
             );
 
@@ -393,7 +393,7 @@ contract('Marmo wallets', function (accounts) {
         });
         it('Should fail to relay is intent is already relayed', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = accounts[9];
             const value = 0;
             const data = '0x';
@@ -443,7 +443,7 @@ contract('Marmo wallets', function (accounts) {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             await web3.eth.sendTransaction({ from: accounts[0], to: wallet.address, value: 1 });
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = accounts[9];
             const value = 1;
             const data = '0x';
@@ -479,7 +479,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -531,7 +531,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -583,7 +583,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -633,7 +633,7 @@ contract('Marmo wallets', function (accounts) {
         it('Should save relayed block number', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -671,7 +671,7 @@ contract('Marmo wallets', function (accounts) {
         it('Should save relayed by', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -711,7 +711,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -762,12 +762,12 @@ contract('Marmo wallets', function (accounts) {
         it('Should relay with multiple dependencies', async function () {
             try {
                 await creator.reveal(accounts[2]);
-            } catch(ignored) { }
+            } catch (ignored) { }
 
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             const wallet2 = await Marmo.at(await creator.marmoOf(accounts[2]));
 
-            const d1dependencies = "0x";
+            const d1dependencies = '0x';
             const d1to = accounts[9];
             const d1value = 0;
             const d1data = '0x';
@@ -787,7 +787,7 @@ contract('Marmo wallets', function (accounts) {
                 d1expiration
             );
 
-            const d2dependencies = "0x";
+            const d2dependencies = '0x';
             const d2to = accounts[9];
             const d2value = 0;
             const d2data = '0x';
@@ -851,9 +851,9 @@ contract('Marmo wallets', function (accounts) {
                             }],
                         }, [
                             [wallet.address, wallet2.address],
-                            [id1Dependency, id2Dependency]
+                            [id1Dependency, id2Dependency],
                         ])
-                    )
+                    ),
                 ])
             );
 
@@ -894,12 +894,12 @@ contract('Marmo wallets', function (accounts) {
         it('Should fail relay with multiple dependencies, if one is not filled', async function () {
             try {
                 await creator.reveal(accounts[2]);
-            } catch(ignored) { }
+            } catch (ignored) { }
 
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             const wallet2 = await Marmo.at(await creator.marmoOf(accounts[2]));
 
-            const d1dependencies = "0x";
+            const d1dependencies = '0x';
             const d1to = accounts[9];
             const d1value = 0;
             const d1data = '0x';
@@ -919,7 +919,7 @@ contract('Marmo wallets', function (accounts) {
                 d1expiration
             );
 
-            const d2dependencies = "0x";
+            const d2dependencies = '0x';
             const d2to = accounts[9];
             const d2value = 0;
             const d2data = '0x';
@@ -970,9 +970,9 @@ contract('Marmo wallets', function (accounts) {
                             }],
                         }, [
                             [wallet.address, wallet2.address],
-                            [id1Dependency, id2Dependency]
+                            [id1Dependency, id2Dependency],
                         ])
-                    )
+                    ),
                 ])
             );
 
@@ -1006,7 +1006,7 @@ contract('Marmo wallets', function (accounts) {
                 salt,
                 expiration,
                 signature
-            ), "Dependency is not satisfied");
+            ), 'Dependency is not satisfied');
 
             (await wallet.relayedBy(id)).should.not.be.equals(accounts[0]);
         });
@@ -1019,7 +1019,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -1053,7 +1053,7 @@ contract('Marmo wallets', function (accounts) {
             const signature = signHash(id, privs[1]);
 
             // Create cancel intent
-            const cdependencies = "0x";
+            const cdependencies = '0x';
             const cto = wallet.address;
             const cvalue = 0;
             const cdata = web3.eth.abi.encodeFunctionCall({
@@ -1120,7 +1120,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -1180,7 +1180,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -1216,7 +1216,7 @@ contract('Marmo wallets', function (accounts) {
             );
 
             // Create cancel intent
-            const cdependencies = "0x";
+            const cdependencies = '0x';
             const cto = wallet.address;
             const cvalue = 0;
             const cdata = web3.eth.abi.encodeFunctionCall({
@@ -1269,7 +1269,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = "0x";
+            const dependencies = '0x';
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -1290,7 +1290,7 @@ contract('Marmo wallets', function (accounts) {
             );
 
             // Create cancel intent
-            const cdependencies = "0x";
+            const cdependencies = '0x';
             const cto = wallet.address;
             const cvalue = 0;
             const cdata = web3.eth.abi.encodeFunctionCall({
@@ -1318,7 +1318,7 @@ contract('Marmo wallets', function (accounts) {
                 cexpiration
             );
 
-            const c2dependencies = "0x";
+            const c2dependencies = '0x';
             const c2to = wallet.address;
             const c2value = 0;
             const c2data = web3.eth.abi.encodeFunctionCall({

--- a/test/TestMarmoWallets.js
+++ b/test/TestMarmoWallets.js
@@ -76,7 +76,7 @@ contract('Marmo wallets', function (accounts) {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             await web3.eth.sendTransaction({ from: accounts[0], to: wallet.address, value: 1 });
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = accounts[9];
             const value = 1;
             const data = '0x';
@@ -121,7 +121,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -172,7 +172,7 @@ contract('Marmo wallets', function (accounts) {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             await web3.eth.sendTransaction({ from: accounts[0], to: wallet.address, value: 1 });
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = accounts[9];
             const value = 1;
             const data = '0x';
@@ -226,13 +226,13 @@ contract('Marmo wallets', function (accounts) {
         });
         it('Should relay is dependencies are filled', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
-            const ddependencies = [];
+            const ddependencies = "0x";
             const dto = accounts[9];
-            const dvalue = 1;
+            const dvalue = 0;
             const ddata = '0x';
             const dminGasLimit = 0;
             const dmaxGasPrice = bn(10).pow(bn(32));
-            const dsalt = '0x';
+            const dsalt = '0x1';
             const dexpiration = bn(10).pow(bn(24));
 
             const idDependency = await wallet.encodeTransactionData(
@@ -248,7 +248,37 @@ contract('Marmo wallets', function (accounts) {
 
             await web3.eth.sendTransaction({ from: accounts[0], to: wallet.address, value: 1 });
 
-            const dependencies = [idDependency];
+            const dsignature = signHash(idDependency, privs[1]);
+            await wallet.relay(
+                ddependencies,
+                dto,
+                dvalue,
+                ddata,
+                dminGasLimit,
+                dmaxGasPrice,
+                dsalt,
+                dexpiration,
+                dsignature
+            );
+
+            (await wallet.relayedBy(idDependency)).should.be.equal(accounts[0]);
+
+            const dependencies = eutils.bufferToHex(
+                Buffer.concat([
+                    eutils.toBuffer(wallet.address),
+                    eutils.toBuffer(
+                        web3.eth.abi.encodeFunctionCall({
+                            name: 'relayedBy',
+                            type: 'function',
+                            inputs: [{
+                                type: 'bytes32',
+                                name: 'id',
+                            }],
+                        }, [idDependency])
+                    )
+                ])
+            );
+
             const to = accounts[8];
             const value = 2;
             const data = '0x';
@@ -290,13 +320,13 @@ contract('Marmo wallets', function (accounts) {
         });
         it('Should fail to relay if dependencies are not filled', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
-            const ddependencies = [];
+            const ddependencies = "0x";
             const dto = accounts[9];
             const dvalue = 1;
             const ddata = '0x';
             const dminGasLimit = 0;
             const dmaxGasPrice = bn(10).pow(bn(32));
-            const dsalt = '0xaaaaaa1';
+            const dsalt = '0xaaaaaa12';
             const dexpiration = bn(10).pow(bn(24));
 
             const idDependency = await wallet.encodeTransactionData(
@@ -310,7 +340,22 @@ contract('Marmo wallets', function (accounts) {
                 dexpiration
             );
 
-            const dependencies = [idDependency];
+            const dependencies = eutils.bufferToHex(
+                Buffer.concat([
+                    eutils.toBuffer(wallet.address),
+                    eutils.toBuffer(
+                        web3.eth.abi.encodeFunctionCall({
+                            name: 'relayedBy',
+                            type: 'function',
+                            inputs: [{
+                                type: 'bytes32',
+                                name: 'id',
+                            }],
+                        }, [idDependency])
+                    )
+                ])
+            );
+
             const to = accounts[9];
             const value = 1;
             const data = '0x';
@@ -345,7 +390,7 @@ contract('Marmo wallets', function (accounts) {
         });
         it('Should fail to relay is intent is already relayed', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
-            const dependencies = [];
+            const dependencies = "0x";
             const to = accounts[9];
             const value = 0;
             const data = '0x';
@@ -395,7 +440,7 @@ contract('Marmo wallets', function (accounts) {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
             await web3.eth.sendTransaction({ from: accounts[0], to: wallet.address, value: 1 });
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = accounts[9];
             const value = 1;
             const data = '0x';
@@ -431,7 +476,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -483,7 +528,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -535,7 +580,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -585,7 +630,7 @@ contract('Marmo wallets', function (accounts) {
         it('Should save relayed block number', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -623,7 +668,7 @@ contract('Marmo wallets', function (accounts) {
         it('Should save relayed by', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -663,7 +708,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -720,7 +765,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -754,7 +799,7 @@ contract('Marmo wallets', function (accounts) {
             const signature = signHash(id, privs[1]);
 
             // Create cancel intent
-            const cdependencies = [];
+            const cdependencies = "0x";
             const cto = wallet.address;
             const cvalue = 0;
             const cdata = web3.eth.abi.encodeFunctionCall({
@@ -821,7 +866,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = testToken.address;
             const value = 0;
             const data = web3.eth.abi.encodeFunctionCall({
@@ -881,7 +926,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -917,7 +962,7 @@ contract('Marmo wallets', function (accounts) {
             );
 
             // Create cancel intent
-            const cdependencies = [];
+            const cdependencies = "0x";
             const cto = wallet.address;
             const cvalue = 0;
             const cdata = web3.eth.abi.encodeFunctionCall({
@@ -970,7 +1015,7 @@ contract('Marmo wallets', function (accounts) {
             await testToken.setBalance(wallet.address, 10);
             await testToken.setBalance(accounts[9], 0);
 
-            const dependencies = [];
+            const dependencies = "0x";
             const to = wallet.address;
             const value = 0;
             const data = '0x';
@@ -991,7 +1036,7 @@ contract('Marmo wallets', function (accounts) {
             );
 
             // Create cancel intent
-            const cdependencies = [];
+            const cdependencies = "0x";
             const cto = wallet.address;
             const cvalue = 0;
             const cdata = web3.eth.abi.encodeFunctionCall({
@@ -1019,7 +1064,7 @@ contract('Marmo wallets', function (accounts) {
                 cexpiration
             );
 
-            const c2dependencies = [];
+            const c2dependencies = "0x";
             const c2to = wallet.address;
             const c2value = 0;
             const c2data = web3.eth.abi.encodeFunctionCall({

--- a/test/TestMarmoWallets.js
+++ b/test/TestMarmoWallets.js
@@ -389,7 +389,7 @@ contract('Marmo wallets', function (accounts) {
                 salt,
                 expiration,
                 signature
-            ), 'Dependencies are not satisfied');
+            ), 'Dependency is not satisfied');
         });
         it('Should fail to relay is intent is already relayed', async function () {
             const wallet = await Marmo.at(await creator.marmoOf(accounts[1]));
@@ -1006,7 +1006,7 @@ contract('Marmo wallets', function (accounts) {
                 salt,
                 expiration,
                 signature
-            ), "Dependencies are not satisfied");
+            ), "Dependency is not satisfied");
 
             (await wallet.relayedBy(id)).should.not.be.equals(accounts[0]);
         });


### PR DESCRIPTION
Replaces the list of bytes32[] ids by a single staticcall, this allows for more flexible dependencies, for example:

- Cross-wallets dependencies
- OR dependencies
- Dependencies not related to intents Ej: Account has 10 ETH