### PR TITLE
Modular execution unit

### DIFF
--- a/contracts/implementations/MarmoImp.sol
+++ b/contracts/implementations/MarmoImp.sol
@@ -1,0 +1,85 @@
+pragma solidity ^0.5.0;
+
+
+contract MarmoImp {
+    uint256 private constant EXTRA_GAS = 21000;
+
+    event Receipt(
+        bytes32 indexed _id,
+        bool _success,
+        bytes _result
+    );
+
+    function() external payable {
+        (
+            bytes32 id,
+            bytes memory data
+        ) = abi.decode(
+            msg.data, (
+                bytes32,
+                bytes
+            )
+        );
+
+        bytes memory dependency;
+        address to;
+        uint256 value;
+        uint256 minGasLimit;
+        uint256 maxGasPrice;
+        uint256 expiration;
+
+        (
+            dependency,
+            to,
+            value,
+            data,
+            minGasLimit,
+            maxGasPrice,
+            expiration
+        ) = abi.decode(
+            data, (
+                bytes,
+                address,
+                uint256,
+                bytes,
+                uint256,
+                uint256,
+                uint256
+            )
+        );
+
+        require(now < expiration, "Intent is expired");
+        require(tx.gasprice < maxGasPrice, "Gas price too high");
+        require(_checkDependency(dependency), "Dependency is not satisfied");
+        require(gasleft() - EXTRA_GAS > minGasLimit, "gasleft too low");
+
+        (bool success, bytes memory result) = to.call.gas(gasleft() - EXTRA_GAS).value(value)(data);
+
+        emit Receipt(
+            id,
+            success,
+            result
+        );
+    }
+
+    // [160 bits (target) + n bits (data)]
+    function _checkDependency(bytes memory _dependency) internal view returns (bool result) {
+        if (_dependency.length == 0) {
+            result = true;
+        } else {
+            assembly {
+                let response := mload(0x40)
+                let success := staticcall(
+                    gas,
+                    mload(add(_dependency, 20)),
+                    add(52, _dependency),
+                    sub(mload(_dependency), 20),
+                    response,
+                    32
+                )
+
+                result := and(gt(success, 0), gt(mload(response), 0))
+            }
+        }
+    }
+}

--- a/test/TestMarmoWallets.js
+++ b/test/TestMarmoWallets.js
@@ -40,7 +40,7 @@ function signHash (hash, priv) {
     return eutils.bufferToHex(Buffer.concat([sig.r, sig.s, eutils.toBuffer(sig.v)]));
 }
 
-function encodeImpData(
+function encodeImpData (
     dependencies,
     to,
     value,
@@ -51,12 +51,12 @@ function encodeImpData(
     expiration
 ) {
     return web3.eth.abi.encodeParameters(
-        ["bytes", "address", "uint256", "bytes", "uint256", "uint256", "uint256", "bytes32"],
+        ['bytes', 'address', 'uint256', 'bytes', 'uint256', 'uint256', 'uint256', 'bytes32'],
         [dependencies, to, value, data, minGasLimit.toString(), maxGasPrice.toString(), expiration.toString(), salt]
     );
 }
 
-function calcId(
+function calcId (
     wallet,
     implementation,
     data
@@ -64,12 +64,13 @@ function calcId(
     return web3.utils.soliditySha3(
         { t: 'address', v: wallet },
         { t: 'address', v: implementation },
-        { t: 'bytes32', v: 
+        { t: 'bytes32',
+            v:
             web3.utils.soliditySha3(
                 { t: 'bytes', v: data }
-            )
+            ),
         }
-    )
+    );
 }
 
 contract('Marmo wallets', function (accounts) {
@@ -166,7 +167,7 @@ contract('Marmo wallets', function (accounts) {
             const expiration = bn(10).pow(bn(24));
 
             const callData = web3.eth.abi.encodeParameters(
-                ["bytes", "address", "uint256", "bytes", "uint256", "uint256", "uint256"],
+                ['bytes', 'address', 'uint256', 'bytes', 'uint256', 'uint256', 'uint256'],
                 [dependencies, to, value, data, minGasLimit, maxGasPrice.toString(), expiration.toString()]
             );
 
@@ -1057,7 +1058,7 @@ contract('Marmo wallets', function (accounts) {
             const id2Dependency = calcId(
                 wallet2.address,
                 marmoImp.address,
-                calldata1Dependency
+                calldata2Dependency
             );
 
             const d1signature = signHash(id1Dependency, privs[1]);
@@ -1378,11 +1379,11 @@ contract('Marmo wallets', function (accounts) {
 
             const log = web3.eth.abi.decodeLog([{
                 type: 'bool',
-                name: '_success'
-            },{
+                name: '_success',
+            }, {
                 type: 'bytes',
                 name: '_result',
-                indexed: true
+                indexed: true,
             }], cancelReceipt.receipt.rawLogs[1].data, []);
 
             (log._success).should.be.equals(false);
@@ -1508,22 +1509,22 @@ contract('Marmo wallets', function (accounts) {
 
             const log1 = web3.eth.abi.decodeLog([{
                 type: 'bool',
-                name: '_success'
-            },{
+                name: '_success',
+            }, {
                 type: 'bytes',
                 name: '_result',
-                indexed: true
+                indexed: true,
             }], cancelReceipt1.receipt.rawLogs[1].data, []);
 
             (log1._success).should.be.equals(true);
 
             const log2 = web3.eth.abi.decodeLog([{
                 type: 'bool',
-                name: '_success'
-            },{
+                name: '_success',
+            }, {
                 type: 'bytes',
                 name: '_result',
-                indexed: true
+                indexed: true,
             }], cancelReceipt2.receipt.rawLogs[1].data, []);
 
             (log2._success).should.be.equals(false);


### PR DESCRIPTION
- Split relay logic from signature validation, this simplifies the Marmo core logic
- Marmo relays a delegatecall, not a call, this allows to upgrade and add features to already created wallets, (multiple intents with one signature, pay gas with tokens, approve and call, more or less relayer malleability, etc)
- Scheme for implementations, the first 32 bytes is the ID of the Intent, the rest of the call is the data for the relayer.