### PR TITLE
Add selfdestruct wallet demostration

### DIFF
--- a/contracts/test/TestSelfDestruct.sol
+++ b/contracts/test/TestSelfDestruct.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.2;
+
+
+contract TestSelfDestruct {
+    function() external {
+        selfdestruct(msg.sender);
+    }
+}

--- a/test/TestMarmoWallets.js
+++ b/test/TestMarmoWallets.js
@@ -5,6 +5,7 @@ const DepsUtils = artifacts.require('./DepsUtils.sol');
 const TestERC20 = artifacts.require('./TestERC20.sol');
 const TestOutOfGasContract = artifacts.require('./TestOutOfGasContract.sol');
 const TestTransfer = artifacts.require('./TestTransfer.sol');
+const TestSelfDestruct = artifacts.require('./TestSelfDestruct.sol');
 
 const eutils = require('ethereumjs-util');
 const Helper = require('./Helper.js');
@@ -79,6 +80,7 @@ contract('Marmo wallets', function (accounts) {
     let marmoImp;
     let testToken;
     let depsUtils;
+    let destructImp;
 
     before(async function () {
         // Validate test node
@@ -94,6 +96,7 @@ contract('Marmo wallets', function (accounts) {
         marmoImp = await MarmoImp.new();
         depsUtils = await DepsUtils.new();
         testToken = await TestERC20.new();
+        destructImp = await TestSelfDestruct.new();
     });
     describe('Create marmo wallets', function () {
         it('Should reveal the marmo wallet', async function () {
@@ -1549,6 +1552,129 @@ contract('Marmo wallets', function (accounts) {
             await transferUtil.transfer(rwallet, { from: accounts[9], value: 100 });
 
             bn(await web3.eth.getBalance(rwallet)).should.be.a.bignumber.that.equals(bn(100));
+        });
+    });
+    describe("Destroy", function () {
+        it("Wallet is destroyable", async function () {
+            // Reveal wallet
+            await creator.reveal(accounts[6]);
+            const wallet = await Marmo.at(await creator.marmoOf(accounts[6]));
+
+            // Set balance and transfer
+            await testToken.setBalance(wallet.address, 10);
+            const dependencies = '0x';
+            const to = testToken.address;
+            const value = 0;
+            const data = web3.eth.abi.encodeFunctionCall({
+                name: 'transfer',
+                type: 'function',
+                inputs: [{
+                    type: 'address',
+                    name: 'to',
+                }, {
+                    type: 'uint256',
+                    name: 'value',
+                }],
+            }, [accounts[9], 2]);
+
+            const minGasLimit = bn(2000000);
+            const maxGasPrice = bn(10).pow(bn(32));
+            const expiration = await Helper.getBlockTime() + 60;
+            let salt = '0x';
+
+            let callData = encodeImpData(
+                dependencies,
+                to,
+                value,
+                data,
+                minGasLimit,
+                maxGasPrice,
+                salt,
+                expiration
+            );
+
+            let id = calcId(
+                wallet.address,
+                marmoImp.address,
+                callData
+            );
+
+            let signature = signHash(id, privs[6]);
+            await wallet.relay(
+                marmoImp.address,
+                callData,
+                signature
+            );
+
+            const ogcalldata = callData;
+            const ogsignature = signature;
+
+            (await testToken.balanceOf(wallet.address)).should.be.a.bignumber.that.equals(bn(8));
+
+            // Destroy wallet
+            id = calcId(
+                wallet.address,
+                destructImp.address,
+                "0x00"
+            );
+
+            await wallet.relay(
+                destructImp.address,
+                "0x00",
+                signHash(id, privs[6])
+            )
+
+            // Wallet should be destroyed
+            // should fail to send tokens
+            salt = "0x01";
+            callData = encodeImpData(
+                dependencies,
+                to,
+                value,
+                data,
+                minGasLimit,
+                maxGasPrice,
+                salt,
+                expiration
+            );
+            
+            id = calcId(
+                wallet.address,
+                marmoImp.address,
+                callData
+            );
+
+            signature = signHash(id, privs[6]);
+            await wallet.relay(
+                marmoImp.address,
+                callData,
+                signature
+            );
+
+            // token count remains the same
+            (await testToken.balanceOf(wallet.address)).should.be.a.bignumber.that.equals(bn(8));
+
+            // Recreate wallet
+            await creator.reveal(accounts[6]);
+
+            // Relay token send
+            await wallet.relay(
+                marmoImp.address,
+                callData,
+                signature
+            );
+
+            (await testToken.balanceOf(wallet.address)).should.be.a.bignumber.that.equals(bn(6));
+
+            // WARNING
+            // Loses replay protection and receipts of previous intents
+            await wallet.relay(
+                marmoImp.address,
+                ogcalldata,
+                ogsignature
+            );
+
+            (await testToken.balanceOf(wallet.address)).should.be.a.bignumber.that.equals(bn(4));
         });
     });
 });

--- a/test/TestMarmoWallets.js
+++ b/test/TestMarmoWallets.js
@@ -1554,8 +1554,8 @@ contract('Marmo wallets', function (accounts) {
             bn(await web3.eth.getBalance(rwallet)).should.be.a.bignumber.that.equals(bn(100));
         });
     });
-    describe("Destroy", function () {
-        it("Wallet is destroyable", async function () {
+    describe('Destroy', function () {
+        it('Wallet is destroyable', async function () {
             // Reveal wallet
             await creator.reveal(accounts[6]);
             const wallet = await Marmo.at(await creator.marmoOf(accounts[6]));
@@ -1615,18 +1615,18 @@ contract('Marmo wallets', function (accounts) {
             id = calcId(
                 wallet.address,
                 destructImp.address,
-                "0x00"
+                '0x00'
             );
 
             await wallet.relay(
                 destructImp.address,
-                "0x00",
+                '0x00',
                 signHash(id, privs[6])
-            )
+            );
 
             // Wallet should be destroyed
             // should fail to send tokens
-            salt = "0x01";
+            salt = '0x01';
             callData = encodeImpData(
                 dependencies,
                 to,
@@ -1637,7 +1637,7 @@ contract('Marmo wallets', function (accounts) {
                 salt,
                 expiration
             );
-            
+
             id = calcId(
                 wallet.address,
                 marmoImp.address,


### PR DESCRIPTION
Add test case *selfdestruct* wallet using bad implementation:

1. Reveal wallet A
2. Send tokens from wallet A (Intent Z)
3. Self destruct wallet A
4. Wallet A can't transfer tokens
5. Reveal wallet A (2)
6. Send tokens from wallet A (Intent X)
7. Replay Intent Z and send tokens from wallet A

Wallets can be recreated after a selfdestruct event, using the same *reveal()* method used to create the wallets.

*Warning*:
All previously relayed Intents can be replayed for a second time because selfdestruct deletes the storage of the contract. 